### PR TITLE
Add support of custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ None.
 Role Variables
 --------------
 
-None.
+`iptables_rules_ipv4` and `iptables_rules_ipv6` variables specify path to custom
+rule dumps (IPv4 and IPv6 respectively). Rule dump format corresponds to
+`iptables-save` (`ip6tables-save`) output.
 
 Dependencies
 ------------
@@ -30,6 +32,9 @@ Example Playbook
     - name: configure firewall
       ansible.builtin.import_role:
         name: iptables
+      vars:
+        iptables_rules_ipv4: config/iptables.ipv4.rules
+        iptables_rules_ipv6: config/iptables.ipv6.rules
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+iptables_rules_ipv4: rules.v4
+iptables_rules_ipv6: rules.v6

--- a/molecule/custom_rules/converge.yml
+++ b/molecule/custom_rules/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: converge
+  hosts: instance
+  tasks:
+    - name: configure firewall
+      ansible.builtin.import_role:
+        name: iptables

--- a/molecule/custom_rules/host_vars/instance.yml
+++ b/molecule/custom_rules/host_vars/instance.yml
@@ -1,0 +1,2 @@
+---
+iptables_rules_ipv4: iptables.ipv4.rules

--- a/molecule/custom_rules/iptables.ipv4.rules
+++ b/molecule/custom_rules/iptables.ipv4.rules
@@ -1,0 +1,14 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+
+--append=INPUT --in-interface=lo --jump=ACCEPT
+
+--append=INPUT --match=conntrack --ctstate=RELATED,ESTABLISHED --jump=ACCEPT
+--append=INPUT --match=conntrack --ctstate=INVALID --jump=DROP
+
+--append=INPUT --protocol=udp --match=udp --source-port=67 --destination-port=68 --jump=ACCEPT
+--append=INPUT --protocol=tcp --match=tcp --destination-port=22 --jump=ACCEPT
+
+COMMIT

--- a/molecule/custom_rules/molecule.yml
+++ b/molecule/custom_rules/molecule.yml
@@ -1,0 +1,19 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: ./lint.sh
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian11-ansible:latest
+    pre_build_image: true
+    privileged: true
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    keep_volumes: false
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/custom_rules/prepare.yml
+++ b/molecule/custom_rules/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: prepare
+  hosts: instance
+  gather_facts: no
+  tasks:
+    - name: install Python 3 for Ansible
+      ansible.builtin.raw: test -e /usr/bin/python3 || (apt-get update && apt-get install --yes python3-minimal)
+      changed_when: no

--- a/molecule/custom_rules/verify.yml
+++ b/molecule/custom_rules/verify.yml
@@ -1,0 +1,30 @@
+---
+- name: verify
+  hosts: instance
+  gather_facts: no
+  tasks:
+    - name: list IPv4 rules
+      ansible.builtin.command: iptables --list-rules
+      changed_when: no
+      register: _result
+
+    - name: check number of IPv4 rules
+      ansible.builtin.assert:
+        that: _result.stdout_lines|length == 8
+
+    - name: check IPv4 rules
+      ansible.builtin.assert:
+        that: _result.stdout_lines[i] == _expect[i]
+      loop: "{{ range(0, _result.stdout_lines|length)|list }}"
+      loop_control:
+        loop_var: i
+      vars:
+        _expect:
+          - "-P INPUT DROP"
+          - "-P FORWARD DROP"
+          - "-P OUTPUT ACCEPT"
+          - "-A INPUT -i lo -j ACCEPT"
+          - "-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"
+          - "-A INPUT -m conntrack --ctstate INVALID -j DROP"
+          - "-A INPUT -p udp -m udp --sport 67 --dport 68 -j ACCEPT"
+          - "-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: set IPv4 rules
   ansible.builtin.copy:
-    src: rules.v4
+    src: "{{ iptables_rules_ipv4 }}"
     dest: /etc/iptables/rules.v4
     mode: u=rw,g=,o=
   notify:
@@ -25,7 +25,7 @@
 
 - name: set IPv6 rules
   ansible.builtin.copy:
-    src: rules.v6
+    src: "{{ iptables_rules_ipv6 }}"
     dest: /etc/iptables/rules.v6
     mode: u=rw,g=,o=
   notify:


### PR DESCRIPTION
Custom rules may be specified using `iptables_rules_ipv4` and `iptables_rules_ipv6` variables.