### PR TITLE
Fix "All names should start with an uppercase letter" warning

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: load IPv4 rules
+- name: Load IPv4 rules
   ansible.builtin.command: iptables-restore /etc/iptables/rules.v4
 
-- name: load IPv6 rules
+- name: Load IPv6 rules
   ansible.builtin.command: ip6tables-restore /etc/iptables/rules.v6

--- a/molecule/custom_rules/converge.yml
+++ b/molecule/custom_rules/converge.yml
@@ -1,7 +1,7 @@
 ---
-- name: converge
+- name: Converge
   hosts: instance
   tasks:
-    - name: configure firewall
+    - name: Configure firewall
       ansible.builtin.import_role:
         name: iptables

--- a/molecule/custom_rules/prepare.yml
+++ b/molecule/custom_rules/prepare.yml
@@ -1,8 +1,8 @@
 ---
-- name: prepare
+- name: Prepare
   hosts: instance
   gather_facts: no
   tasks:
-    - name: install Python 3 for Ansible
+    - name: Install Python 3 for Ansible
       ansible.builtin.raw: test -e /usr/bin/python3 || (apt-get update && apt-get install --yes python3-minimal)
       changed_when: no

--- a/molecule/custom_rules/verify.yml
+++ b/molecule/custom_rules/verify.yml
@@ -1,18 +1,18 @@
 ---
-- name: verify
+- name: Verify
   hosts: instance
   gather_facts: no
   tasks:
-    - name: list IPv4 rules
+    - name: List IPv4 rules
       ansible.builtin.command: iptables --list-rules
       changed_when: no
       register: _result
 
-    - name: check number of IPv4 rules
+    - name: Check number of IPv4 rules
       ansible.builtin.assert:
         that: _result.stdout_lines|length == 8
 
-    - name: check IPv4 rules
+    - name: Check IPv4 rules
       ansible.builtin.assert:
         that: _result.stdout_lines[i] == _expect[i]
       loop: "{{ range(0, _result.stdout_lines|length)|list }}"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,7 +1,7 @@
 ---
-- name: converge
+- name: Converge
   hosts: instance
   tasks:
-    - name: configure firewall
+    - name: Configure firewall
       ansible.builtin.import_role:
         name: iptables

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,8 +1,8 @@
 ---
-- name: prepare
+- name: Prepare
   hosts: instance
   gather_facts: no
   tasks:
-    - name: install Python 3 for Ansible
+    - name: Install Python 3 for Ansible
       ansible.builtin.raw: test -e /usr/bin/python3 || (apt-get update && apt-get install --yes python3-minimal)
       changed_when: no

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,18 +1,18 @@
 ---
-- name: verify
+- name: Verify
   hosts: instance
   gather_facts: no
   tasks:
-    - name: list IPv4 rules
+    - name: List IPv4 rules
       ansible.builtin.command: iptables --list-rules
       changed_when: no
       register: _result
 
-    - name: check number of IPv4 rules
+    - name: Check number of IPv4 rules
       ansible.builtin.assert:
         that: _result.stdout_lines|length == 7
 
-    - name: check IPv4 rules
+    - name: Check IPv4 rules
       ansible.builtin.assert:
         that: _result.stdout_lines[i] == _expect[i]
       loop: "{{ range(0, _result.stdout_lines|length)|list }}"
@@ -28,16 +28,16 @@
           - "-A INPUT -m conntrack --ctstate INVALID -j DROP"
           - "-A INPUT -p udp -m udp --sport 67 --dport 68 -j ACCEPT"
 
-    - name: list IPv6 rules
+    - name: List IPv6 rules
       ansible.builtin.command: ip6tables --list-rules
       changed_when: no
       register: _result
 
-    - name: check number of IPv6 rules
+    - name: Check number of IPv6 rules
       ansible.builtin.assert:
         that: _result.stdout_lines|length == 6
 
-    - name: check IPv6 rules
+    - name: Check IPv6 rules
       ansible.builtin.assert:
         that: _result.stdout_lines[i] == _expect[i]
       loop: "{{ range(0, _result.stdout_lines|length)|list }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: install iptables-persistent
+- name: Install iptables-persistent
   ansible.builtin.apt:
     name:
       - iptables-persistent
@@ -7,7 +7,7 @@
     force_apt_get: yes
     update_cache: yes
 
-- name: create configuration directory
+- name: Create configuration directory
   ansible.builtin.file:
     path: /etc/iptables
     state: directory
@@ -15,23 +15,23 @@
     group: root
     mode: u=rwx,g=,o=
 
-- name: set IPv4 rules
+- name: Set IPv4 rules
   ansible.builtin.copy:
     src: "{{ iptables_rules_ipv4 }}"
     dest: /etc/iptables/rules.v4
     mode: u=rw,g=,o=
   notify:
-    - load IPv4 rules
+    - Load IPv4 rules
 
-- name: set IPv6 rules
+- name: Set IPv6 rules
   ansible.builtin.copy:
     src: "{{ iptables_rules_ipv6 }}"
     dest: /etc/iptables/rules.v6
     mode: u=rw,g=,o=
   notify:
-    - load IPv6 rules
+    - Load IPv6 rules
 
-- name: enable netfilter-persistent
+- name: Enable netfilter-persistent
   ansible.builtin.systemd:
     name: netfilter-persistent.service
     state: started


### PR DESCRIPTION
Fix Ansible Lint `name[casing]` (All names should start with an uppercase letter) warning.