### PR TITLE
Simplify lint.sh helper script

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -1,54 +1,16 @@
 #!/bin/sh
 
-set -o errexit
-
-exit_handler() {
-    if [ $? -ne 0 ]; then
-        echo "Failure" >&2
-    fi
-}
-
-get_roles_dir() {
-    local cache_key
-    local cache_dir
-
-    # See:
-    # https://github.com/ansible/ansible-compat/blob/1d53bc95b95485710c179d6186deebf25aa930bc/src/ansible_compat/prerun.py
-    cache_key=$(printf $(basename "${PWD}") | sha256sum -b - | head -c 6)
-    cache_dir="${HOME}/.cache/ansible-compat/${cache_key}"
-
-    echo "${cache_dir}/roles"
-}
-
-ansiblelint_wrapper() {
-    local role_name=$(basename "${PWD}")
-    local exit_status
-    local mock_path
-
-    # Set up role mock. A workaround to bypass the following error:
-    # internal-error: the role '<...>' was not found in <...>
-    # See https://github.com/ansible/ansible-lint/issues/1329
-    mock_path="$(get_roles_dir)/${role_name}"
-    mkdir -p "${mock_path}"
-
-    set +o errexit
-
-    ansible-lint
-    exit_status=$?
-
-    set -o errexit
-
-    # Tear down mock. Molecule imports roles from the same chache directory.
-    rm -r -f "${mock_path}"
-
-    if [ ${exit_status} -ne 0 ]; then
-        exit 1
-    fi
-}
-
-trap exit_handler EXIT
+set -o nounset
 
 echo "Running ansible-lint..."
-ansiblelint_wrapper
+ANSIBLE_ROLES_PATH="${MOLECULE_EPHEMERAL_DIRECTORY}/roles" \
+ANSIBLE_COLLECTIONS_PATH="${MOLECULE_EPHEMERAL_DIRECTORY}/collections" \
+ansible-lint \
+    "${MOLECULE_PROJECT_DIRECTORY}" \
+    "${MOLECULE_SCENARIO_DIRECTORY}"
+if [ $? -ne 0 ]; then
+    echo "Error: ansible-lint failed" >&2
+    exit 1
+fi
 
 echo "Success"

--- a/molecule/custom_rules/converge.yml
+++ b/molecule/custom_rules/converge.yml
@@ -4,4 +4,4 @@
   tasks:
     - name: Configure firewall
       ansible.builtin.import_role:
-        name: iptables
+        name: yabusygin.iptables

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,4 +4,4 @@
   tasks:
     - name: Configure firewall
       ansible.builtin.import_role:
-        name: iptables
+        name: yabusygin.iptables


### PR DESCRIPTION
Use Molecule to manage role mock.