### PR TITLE
Fix example playbook formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Example Playbook
 
 ```yaml
 ---
-- name: example playbook
+- name: Example playbook
   hosts: server
   tasks:
-    - name: configure firewall
+    - name: Configure firewall
       ansible.builtin.import_role:
         name: iptables
       vars:


### PR DESCRIPTION
Now the example playbook meets the following Ansible Lint rule: "All names should start with an uppercase letter".