### PR TITLE
Add test.sh helper script

### DIFF
--- a/molecule/custom_rules/molecule.yml
+++ b/molecule/custom_rules/molecule.yml
@@ -6,7 +6,7 @@ driver:
 lint: ./lint.sh
 platforms:
   - name: instance
-    image: geerlingguy/docker-debian11-ansible:latest
+    image: ${TEST_IMAGE}
     pre_build_image: true
     privileged: true
     command: ""

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 lint: ./lint.sh
 platforms:
   - name: instance
-    image: geerlingguy/docker-debian11-ansible:latest
+    image: ${TEST_IMAGE}
     pre_build_image: true
     privileged: true
     command: ""

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+platforms="geerlingguy/docker-debian11-ansible:latest"
+
+for image in ${platforms}; do
+    echo "Running Molecule tests for '${image}'..."
+    TEST_IMAGE="${image}" molecule test --all
+    if [ $? -ne 0 ]; then
+        echo "Error: Molecule test failed (platform: ${image})" >&2
+        exit 1
+    fi
+done
+
+echo "Success: all tests are passed"


### PR DESCRIPTION
The `test.sh` helper script is designed for test platforms to be easily added.