### PR TITLE
Add Ubuntu 22.04 (Jammy Jellyfish) support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,9 @@ galaxy_info:
     - name: Debian
       versions:
         - bullseye
+    - name: Ubuntu
+      versions:
+        - jammy
   galaxy_tags:
     - system
     - networking

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-platforms="geerlingguy/docker-debian11-ansible:latest"
+platforms="geerlingguy/docker-debian11-ansible:latest \
+           geerlingguy/docker-ubuntu2204-ansible:latest"
 
 for image in ${platforms}; do
     echo "Running Molecule tests for '${image}'..."


### PR DESCRIPTION
The role is tested under the Ubuntu 22.04 platform.