### PR TITLE
Fix test.sh compatibility with POSIX shell

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
-platforms="geerlingguy/docker-debian11-ansible:latest \
-           geerlingguy/docker-ubuntu2204-ansible:latest"
+# platform images
+set -- \
+    geerlingguy/docker-debian11-ansible:latest \
+    geerlingguy/docker-ubuntu2204-ansible:latest
 
-for image in ${platforms}; do
+for image in "${@}"; do
     echo "Running Molecule tests for '${image}'..."
     TEST_IMAGE="${image}" molecule test --all
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Fix `test.sh` script to use POSIX compatible array of strings.